### PR TITLE
Add back gem host so we don't accidentally release to rubygems

### DIFF
--- a/active_campaign.gemspec
+++ b/active_campaign.gemspec
@@ -14,6 +14,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/coverhound/active_campaign"
   spec.license       = "MIT"
 
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+  end
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Just probably good to have this so we don't accidentally release to the public
